### PR TITLE
Fix cache serialization when using entity framework feature store

### DIFF
--- a/tests/FeatureManagement.Database.Abstractions.Tests/FeatureManagement/Database/Abstractions/FeatureStoreWithCircularReference.cs
+++ b/tests/FeatureManagement.Database.Abstractions.Tests/FeatureManagement/Database/Abstractions/FeatureStoreWithCircularReference.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using static FeatureManagement.Database.Abstractions.Features;
+
+namespace FeatureManagement.Database.Abstractions;
+
+public class FeatureStoreWithCircularReference : IFeatureStore
+{
+    private readonly IReadOnlyCollection<Feature> _features;
+
+    public FeatureStoreWithCircularReference()
+    {
+        var firstFeature = new Feature
+        {
+            Name = FirstFeature,
+            RequirementType = Microsoft.FeatureManagement.RequirementType.All,
+        };
+        firstFeature.Settings =
+        [
+            new FeatureSettings
+            {
+                FeatureId = firstFeature.Id,
+                Feature = firstFeature,
+                FilterType = FeatureFilterType.TimeWindow,
+                Parameters =
+                    """{"Start": "Mon, 01 May 2023 13:59:59 GMT", "End": "Sat, 01 July 2023 00:00:00 GMT"}"""
+            }
+        ];
+        var secondFeature = new Feature
+        {
+            Name = SecondFeature,
+            RequirementType = Microsoft.FeatureManagement.RequirementType.All,
+        };
+        secondFeature.Settings =
+        [
+            new FeatureSettings
+            {
+                FeatureId = secondFeature.Id,
+                Feature = secondFeature,
+                FilterType = FeatureFilterType.TimeWindow,
+                Parameters =
+                    """{"Start": "Mon, 01 May 2023 13:59:59 GMT", "End": "Sat, 01 July 2023 00:00:00 GMT"}"""
+            }
+        ];
+        _features =
+        [
+            firstFeature,
+            secondFeature
+        ];
+    }
+
+    public Task<Feature> GetFeatureAsync([NotNull] string featureName)
+    {
+        return Task.FromResult(_features.SingleOrDefault(x => x.Name == featureName));
+    }
+
+    public Task<IReadOnlyCollection<Feature>> GetFeaturesAsync()
+    {
+        return Task.FromResult(_features);
+    }
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.MySql.Tests/FeatureManagement/Database/EntityFrameworkCore/MySql/Tests/MySqlFeatureStoreWithCacheTests.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.MySql.Tests/FeatureManagement/Database/EntityFrameworkCore/MySql/Tests/MySqlFeatureStoreWithCacheTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests;
+
+public sealed class MySqlFeatureStoreWithCacheTests(MySqlWithCacheIntegrationTestWebAppFactory factory)
+    : EFCoreFeatureStoreTests<MySqlWithCacheIntegrationTestWebAppFactory>(factory)
+{
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.MySql.Tests/FeatureManagement/Database/EntityFrameworkCore/MySql/Tests/MySqlWithCacheIntegrationTestWebAppFactory.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.MySql.Tests/FeatureManagement/Database/EntityFrameworkCore/MySql/Tests/MySqlWithCacheIntegrationTestWebAppFactory.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using DotNet.Testcontainers.Builders;
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using Testcontainers.MySql;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests;
+
+public sealed class MySqlWithCacheIntegrationTestWebAppFactory : IntegrationTestWebAppFactory<MySqlContainer>
+{
+    private readonly MySqlContainer _mySqlContainer = new MySqlBuilder()
+        .WithName("mysql-test-container-cache")
+        .WithImage("mysql:latest")
+        .WithDatabase("TestDb")
+        .WithUsername("root")
+        .WithPassword("mysqlpassword")
+        .WithPrivileged(true)
+        .WithPortBinding(MySqlBuilder.MySqlPort, assignRandomHostPort: true)
+        .WithCleanUp(true)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MySqlBuilder.MySqlPort))
+        .Build();
+
+    public MySqlWithCacheIntegrationTestWebAppFactory()
+    {
+        _container = _mySqlContainer;
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+        services.AddDatabaseFeatureManagement<CustomEFCoreFeatureStore>()
+            .UseMySql<TestDbContext>(_mySqlContainer.GetConnectionString(),
+                options => options.MigrationsAssembly(Assembly.GetExecutingAssembly().FullName))
+            .WithCacheService();
+    }
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.PostgreSQL.Tests/FeatureManagement/Database/EntityFrameworkCore/PostgreSQL/Tests/PostgreSqlFeatureStoreWithCacheTests.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.PostgreSQL.Tests/FeatureManagement/Database/EntityFrameworkCore/PostgreSQL/Tests/PostgreSqlFeatureStoreWithCacheTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests;
+
+public sealed class PostgreSqlFeatureStoreWithCacheTests(PostgreSqlWithCacheIntegrationTestWebAppFactory factory)
+    : EFCoreFeatureStoreTests<PostgreSqlWithCacheIntegrationTestWebAppFactory>(factory)
+{
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.PostgreSQL.Tests/FeatureManagement/Database/EntityFrameworkCore/PostgreSQL/Tests/PostgreSqlWithCacheIntegrationTestWebAppFactory.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.PostgreSQL.Tests/FeatureManagement/Database/EntityFrameworkCore/PostgreSQL/Tests/PostgreSqlWithCacheIntegrationTestWebAppFactory.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using DotNet.Testcontainers.Builders;
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using Testcontainers.PostgreSql;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests;
+
+public sealed class PostgreSqlWithCacheIntegrationTestWebAppFactory : IntegrationTestWebAppFactory<PostgreSqlContainer>
+{
+    private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder()
+        .WithName("postgresql-test-container-cache")
+        .WithImage("postgres:latest")
+        .WithPortBinding(PostgreSqlBuilder.PostgreSqlPort, assignRandomHostPort: true)
+        .WithCleanUp(true)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(PostgreSqlBuilder.PostgreSqlPort))
+        .Build();
+
+    public PostgreSqlWithCacheIntegrationTestWebAppFactory()
+    {
+        _container = _postgreSqlContainer;
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+        services.AddDatabaseFeatureManagement<CustomEFCoreFeatureStore>()
+            .UseNpgsql<TestDbContext>(_postgreSqlContainer.GetConnectionString(),
+                options => options.MigrationsAssembly(Assembly.GetExecutingAssembly().FullName))
+            .WithCacheService();
+    }
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests/FeatureManagement/Database/EntityFrameworkCore/SqlServer/Tests/SqlServerFeatureStoreWithCacheTests.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests/FeatureManagement/Database/EntityFrameworkCore/SqlServer/Tests/SqlServerFeatureStoreWithCacheTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests;
+
+public sealed class SqlServerFeatureStoreWithCacheTests(SqlServerWithCacheIntegrationTestWebAppFactory factory)
+    : EFCoreFeatureStoreTests<SqlServerWithCacheIntegrationTestWebAppFactory>(factory)
+{
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests/FeatureManagement/Database/EntityFrameworkCore/SqlServer/Tests/SqlServerWithCacheIntegrationTestWebAppFactory.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests/FeatureManagement/Database/EntityFrameworkCore/SqlServer/Tests/SqlServerWithCacheIntegrationTestWebAppFactory.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using DotNet.Testcontainers.Builders;
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using Testcontainers.MsSql;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.SqlServer.Tests;
+
+public sealed class SqlServerWithCacheIntegrationTestWebAppFactory : IntegrationTestWebAppFactory<MsSqlContainer>
+{
+    private readonly MsSqlContainer _sqlServerContainer = new MsSqlBuilder()
+        .WithName("sqlserver-test-container-with-cache")
+        .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        .WithEnvironment("ACCEPT_EULA", "Y")
+        .WithPortBinding(MsSqlBuilder.MsSqlPort, assignRandomHostPort: true)
+        .WithCleanUp(true)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(MsSqlBuilder.MsSqlPort))
+        .Build();
+
+    public SqlServerWithCacheIntegrationTestWebAppFactory()
+    {
+        _container = _sqlServerContainer;
+    }
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        base.ConfigureServices(services);
+        services.AddDatabaseFeatureManagement<CustomEFCoreFeatureStore>()
+            .UseSqlServer<TestDbContext>(_sqlServerContainer.GetConnectionString(),
+                options => options.MigrationsAssembly(Assembly.GetExecutingAssembly().FullName))
+            .WithCacheService();
+    }
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.Sqlite.Tests/FeatureManagement/Database/EntityFrameworkCore/Sqlite/Tests/SqliteFeatureStoreWithCacheTests.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.Sqlite.Tests/FeatureManagement/Database/EntityFrameworkCore/Sqlite/Tests/SqliteFeatureStoreWithCacheTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.Sqlite.Tests;
+
+public sealed class SqliteFeatureStoreWithCacheTests(SqliteWithCacheIntegrationTestWebAppFactory factory)
+    : EFCoreFeatureStoreTests<SqliteWithCacheIntegrationTestWebAppFactory>(factory)
+{
+}

--- a/tests/FeatureManagement.Database.EntityFrameworkCore.Sqlite.Tests/FeatureManagement/Database/EntityFrameworkCore/Sqlite/Tests/SqliteWithCacheIntegrationTestWebAppFactory.cs
+++ b/tests/FeatureManagement.Database.EntityFrameworkCore.Sqlite.Tests/FeatureManagement/Database/EntityFrameworkCore/Sqlite/Tests/SqliteWithCacheIntegrationTestWebAppFactory.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Matteo Ciapparelli.
+// Licensed under the MIT license.
+
+using FeatureManagement.Database.EntityFrameworkCore.Tests;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System.Reflection;
+
+namespace FeatureManagement.Database.EntityFrameworkCore.Sqlite.Tests;
+
+public class SqliteWithCacheIntegrationTestWebAppFactory : WebApplicationFactory<Program>, IAsyncLifetime
+{
+    private const string _InMemoryDatabaseName = "TestDbWithCache";
+    private const string _ConnectionString = $"DataSource={_InMemoryDatabaseName};Mode=Memory;Cache=Shared";
+
+    private SqliteConnection _connection;
+
+    public async Task InitializeAsync()
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        _connection = new SqliteConnection(_ConnectionString);
+        await _connection.OpenAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+    }
+
+    public new async Task DisposeAsync()
+    {
+        using var scope = Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TestDbContext>();
+        await dbContext.Database.EnsureDeletedAsync();
+        await _connection.DisposeAsync();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(ConfigureServices);
+    }
+
+    private void ConfigureServices(IServiceCollection services)
+    {
+        services.RemoveAll(typeof(DbContextOptions<TestDbContext>));
+
+        services.AddDatabaseFeatureManagement<CustomEFCoreFeatureStore>()
+            .UseSqlite<TestDbContext>(_ConnectionString,
+                options => options.MigrationsAssembly(Assembly.GetExecutingAssembly().FullName))
+            .WithCacheService();
+    }
+}


### PR DESCRIPTION
Fixes a bug when adding the cache services with an Entity Framework Feature Store that caused the Json serialization of the cache to fail due to the circular reference from the navigation properties in the entities.